### PR TITLE
take care of compiling issue with gcc version 10

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -1,6 +1,7 @@
 #include <bf/hash.hpp>
 
 #include <cassert>
+#include <stdexcept>
 
 namespace bf {
 


### PR DESCRIPTION
This PR should fix the following problem I have with GCC version 10.

```
/home/heumos/git/odgi/deps/libbf/src/hash.cpp: In member function ‘size_t bf::default_hash_function::operator()(const bf::object&) const’:
/home/heumos/git/odgi/deps/libbf/src/hash.cpp:14:16: error: ‘runtime_error’ is not a member of ‘std’
14 | throw std::runtime_error("object too large");
| ^~~~~~~~~~~~~
/home/heumos/git/odgi/deps/libbf/src/hash.cpp: In member function ‘size_t bf::default_hash_function::operator()(const bf::object&) const’:
/home/heumos/git/odgi/deps/libbf/src/hash.cpp:14:16: error: ‘runtime_error’ is not a member of ‘std’
14 | throw std::runtime_error("object too large");
| ^~~~~~~~~~~~~
```